### PR TITLE
Correctly return encid.ErrNotFound in place of sql.ErrNoRows.

### DIFF
--- a/cmd/encid/main.go
+++ b/cmd/encid/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/aes"
-	"database/sql"
 	"flag"
 	"fmt"
 	"log"
@@ -88,7 +87,7 @@ func (c maincmd) tryEnc(ctx context.Context, fifty bool, typ int, n int64, isRet
 	} else {
 		id, str, err = encid.Encode(ctx, c.ks, typ, n)
 	}
-	if errors.Is(err, sql.ErrNoRows) && !isRetry {
+	if errors.Is(err, encid.ErrNotFound) && !isRetry {
 		if _, err = c.newKeyHelper(ctx, typ); err != nil {
 			return errors.Wrap(err, "creating new key")
 		}

--- a/sqlite/keystore.go
+++ b/sqlite/keystore.go
@@ -58,7 +58,11 @@ func (ks *KeyStore) DecoderByID(ctx context.Context, id int64) (typ int, dec fun
 
 	var k []byte
 
-	if err := ks.db.QueryRowContext(ctx, q, id).Scan(&typ, &k); err != nil {
+	err = ks.db.QueryRowContext(ctx, q, id).Scan(&typ, &k)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil, encid.ErrNotFound
+	}
+	if err != nil {
 		return 0, nil, errors.Wrapf(err, "retrieving key %d", id)
 	}
 
@@ -75,7 +79,11 @@ func (ks *KeyStore) EncoderByType(ctx context.Context, typ int) (id int64, enc f
 
 	var k []byte
 
-	if err := ks.db.QueryRowContext(ctx, q, typ).Scan(&id, &k); err != nil {
+	err = ks.db.QueryRowContext(ctx, q, typ).Scan(&id, &k)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil, encid.ErrNotFound
+	}
+	if err != nil {
 		return 0, nil, errors.Wrapf(err, "retrieving key for type %d", typ)
 	}
 

--- a/sqlite/keystore_test.go
+++ b/sqlite/keystore_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
-	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/bobg/encid"
 	"github.com/bobg/encid/testutil"
 )
 
@@ -31,13 +31,13 @@ func TestKeyStore(t *testing.T) {
 	}
 
 	_, _, err = ks.DecoderByID(ctx, 1)
-	if !errors.Is(err, sql.ErrNoRows) {
-		t.Errorf("got %v, want %v", err, sql.ErrNoRows)
+	if !errors.Is(err, encid.ErrNotFound) {
+		t.Errorf("got %v, want %v", err, encid.ErrNotFound)
 	}
 
 	_, _, err = ks.EncoderByType(ctx, 1)
-	if !errors.Is(err, sql.ErrNoRows) {
-		t.Errorf("got %v, want %v", err, sql.ErrNoRows)
+	if !errors.Is(err, encid.ErrNotFound) {
+		t.Errorf("got %v, want %v", err, encid.ErrNotFound)
 	}
 
 	id, err := ks.NewKey(ctx, 1, aes.BlockSize)


### PR DESCRIPTION
The documentation says that `DecoderByID` and `EncoderByType` must return `encid.ErrNotFound`, but the sqlite implementation was returning `sql.ErrNoRows` instead.