### PR TITLE
Use basexx/v2. Add test coverage.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Modver
         if: ${{ github.event_name == 'pull_request' }}
-        uses: bobg/modver@v2.5.0
+        uses: bobg/modver@v2.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}

--- a/encid_test.go
+++ b/encid_test.go
@@ -2,10 +2,11 @@ package encid_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/bobg/basexx"
+	"github.com/bobg/basexx/v2"
 
 	"github.com/bobg/encid"
 	"github.com/bobg/encid/testutil"
@@ -108,4 +109,32 @@ func (z zeroByteSource) Read(buf []byte) (int, error) {
 		buf[i] = 0
 	}
 	return len(buf), nil
+}
+
+func TestErrs(t *testing.T) {
+	var (
+		ctx = context.Background()
+		ks  = testutil.KeyStore{NumTypes: 1}
+	)
+
+	t.Run("Encode50", func(t *testing.T) {
+		_, _, err := encid.Encode50(ctx, ks, 1000000, 1)
+		if !errors.Is(err, encid.ErrNotFound) {
+			t.Errorf("got error %v, want %v", err, encid.ErrNotFound)
+		}
+	})
+
+	t.Run("Decode50", func(t *testing.T) {
+		_, _, err := encid.Decode50(ctx, ks, 1000000, "1zQqKSwhbq2jGRmBNjZctj1")
+		if !errors.Is(err, encid.ErrNotFound) {
+			t.Errorf("got error %v, want %v", err, encid.ErrNotFound)
+		}
+	})
+
+	t.Run("BadBase50", func(t *testing.T) {
+		_, _, err := encid.Decode50(ctx, ks, 1, "aeiou")
+		if !errors.Is(err, basexx.ErrInvalid) {
+			t.Errorf("got error %v, want %v", err, basexx.ErrInvalid)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bobg/encid
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bobg/basexx/v2 v2.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bobg/encid
 go 1.19
 
 require (
-	github.com/bobg/basexx v1.0.0
+	github.com/bobg/basexx/v2 v2.0.1
 	github.com/bobg/subcmd/v2 v2.2.2
 	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/pkg/errors v0.9.1
@@ -11,7 +11,9 @@ require (
 )
 
 require (
+	github.com/bobg/go-generics/v2 v2.2.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/sync v0.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,10 @@ github.com/ClickHouse/clickhouse-go/v2 v2.16.0 h1:rhMfnPewXPnY4Q4lQRGdYuTLRBRKJE
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
-github.com/bobg/basexx v1.0.0 h1:VHxQcrZV0I5NaGftCuTm93hRd//UtaiwPeJ7wh55BK4=
-github.com/bobg/basexx v1.0.0/go.mod h1:TUZ3/ZfQrnD0AMpTd+1qeiJ8ogd4fo5wbs4d3lwJUD0=
+github.com/bobg/basexx/v2 v2.0.1 h1:TuMdI3nLogGzWnclM+kh50dsFymXMgEujXp/23x1ORA=
+github.com/bobg/basexx/v2 v2.0.1/go.mod h1:xSdI1WkOj9W2VpU74w3lvCIiSdA/04GBCPv5OMpzL9w=
+github.com/bobg/go-generics/v2 v2.2.0 h1:Sw3roCuRqncLz6tp7MdrtdxR48LFyKNOnQgQtmGHBno=
+github.com/bobg/go-generics/v2 v2.2.0/go.mod h1:iPMSRVFlzkJSYOCXQ0n92RA3Vxw0RBv2E8j9ZODXgHk=
 github.com/bobg/subcmd/v2 v2.2.2 h1:5PDmKAqgfxL3Z/teYQD7YXFOh91vC7DWNF3ApEmt+zQ=
 github.com/bobg/subcmd/v2 v2.2.2/go.mod h1:fjEpI7mfn8eXEoQ7+lx+dA22sebrbrIa1VMzplZzjpE=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -24,8 +26,8 @@ github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrt
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
@@ -72,6 +74,8 @@ go.opentelemetry.io/otel/trace v1.20.0 h1:+yxVAPZPbQhbC3OfAkeIVTky6iTFpcr4SiY9om
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=

--- a/testutil/keystore.go
+++ b/testutil/keystore.go
@@ -5,6 +5,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/binary"
+
+	"github.com/bobg/encid"
 )
 
 type KeyStore struct {
@@ -12,6 +14,10 @@ type KeyStore struct {
 }
 
 func (tks KeyStore) cipherByID(keyID int64) (cipher.Block, error) {
+	if keyID > 999999 {
+		return nil, encid.ErrNotFound
+	}
+
 	var buf [16]byte
 	binary.BigEndian.PutUint32(buf[:], uint32(keyID))
 	return aes.NewCipher(buf[:])


### PR DESCRIPTION
This PR switches encid to using v2 of the basexx module and adds test coverage.